### PR TITLE
Adding error checking: Check length of all chunks except IDAT against user limit

### DIFF
--- a/technobear/clds/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
+++ b/technobear/clds/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
@@ -243,6 +243,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+    else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/technobear/clds/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
+++ b/technobear/clds/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
@@ -177,6 +177,22 @@ png_read_chunk_header(png_structrp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+   
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif

--- a/technobear/pmix/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
+++ b/technobear/pmix/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
@@ -243,6 +243,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/technobear/pmix/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
+++ b/technobear/pmix/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
@@ -177,6 +177,22 @@ png_read_chunk_header(png_structrp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+  /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif

--- a/technobear/rngs/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
+++ b/technobear/rngs/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngpread.c
@@ -243,6 +243,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/technobear/rngs/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
+++ b/technobear/rngs/JuceLibraryCode/modules/juce_graphics/image_formats/pnglib/pngrutil.c
@@ -177,6 +177,22 @@ png_read_chunk_header(png_structrp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif


### PR DESCRIPTION
I'm Braden, a CS student at the University of Tennessee, Knoxville, and am completing an Open Source contribution project for my software development class.

Your project is using an older version of libpng that fails to check the length of the chunks being created against the user limit. This could cause problems later on in the execution of the code if the length of the chunks is larger than the user limit. This also ensures that the code is following the limitations set by the user. 

This issue was fixed previously by this commit: https://github.com/glennrp/libpng/commit/347538efbdc21b8df684ebd92d37400b3ce85d55
This fix adds code to pngpread.c and pngrutil.c to check the chunk length against the user limit; I just added the fix to the relevant files in your project's repo.